### PR TITLE
CI jobs timeouts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     name: Install dependencies and Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -35,6 +36,7 @@ jobs:
   deploy:
     name: Deploy to Vercel
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       DEPLOYMENT_URL: ${{ steps.vercel-deploy.outputs.PREVIEW_URL }}
       INSPECT_URL: ${{ steps.vercel-deploy.outputs.INSPECT_URL }}
@@ -84,6 +86,7 @@ jobs:
     name: Cypress run
     needs: [deploy, lint]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -107,6 +110,7 @@ jobs:
     name: Comment on PR with failing tests details
     needs: [deploy, cypress-run]
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     if: always() && needs.cypress-run.result == 'failure' && (github.event_name == 'pull_request')
     steps:
       - name: Checkout
@@ -142,6 +146,7 @@ jobs:
     name: Assign branch specific URL
     needs: [deploy, cypress-run]
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     if: ${{needs.deploy.outputs.DEPLOYMENT_ENVIRONMENT == 'Preview' }}
     outputs:
       BRANCH_DOMAIN: ${{ steps.branch-deployment-url.outputs.BRANCH_DOMAIN }}
@@ -178,6 +183,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     needs: [deploy, cypress-run, assign-branch-url]
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
CI jobs didn't have defined timeout, which led to default 360 minutes timeout, which is unnecessary and resource consuming (happened accidentally twice yesterday). I've defined timeouts that are relevant for each job