### PR TITLE
refactor: tweak linting rules for test files, remove boilerplate in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,5 +97,11 @@ module.exports = {
       ],
     },
   },
+  {
+    files: ['./src/**/*.spec.ts'],
+    rules: {
+      "@typescript-eslint/unbound-method": 'off'
+    }
+  }
   ],
 };

--- a/src/pages/reserve/pages/k-guilder/k-guilder.spec.ts
+++ b/src/pages/reserve/pages/k-guilder/k-guilder.spec.ts
@@ -1,0 +1,56 @@
+import '../../../../utils-testing/setup-testing';
+import { Global } from '../../../../hooks/';
+import { I18N } from '@aurelia/i18n';
+import { IBlockChainStore, IStore } from '../../../../stores';
+import { KGuilder } from './k-guilder';
+import { Registration, ValueConverter } from 'aurelia';
+import { createFixture } from '@aurelia/testing';
+import { describe, expect, it } from 'vitest';
+
+describe('<k-guilder />', () => {
+  it('displays grid cards text', async () => {
+    const { getAllBy } = await createFixture
+      .html(`<k-guilder>`)
+      .deps(...getRegistrations())
+      .build().started;
+
+    const gridCards = getAllBy('k-grid k-card');
+    expect(gridCards).toHaveLength(3);
+
+    const [card1, card2, card3] = gridCards;
+    expect(card1.textContent).toContain('0.2%');
+    expect(card1.textContent).toContain('navigation.reserve.k-guilder.spread.title');
+
+    expect(card2.textContent).toContain('0.4%');
+    expect(card2.textContent).toContain('navigation.reserve.k-guilder.inflation-rate.title');
+
+    expect(card3.textContent).toContain('0.4%');
+    expect(card3.textContent).toContain('navigation.reserve.k-guilder.tobin-tax.title');
+  });
+
+  it.todo('display token info card marketCap, currentPrice and totalSupply');
+  it.todo('display value ratio card title with translation');
+
+  function getRegistrations(overrides?: Partial<IBlockChainStore>) {
+    const createMockStoreRegistration = () =>
+      Registration.instance(IStore, {
+        blockChainStore: {},
+      });
+    const createMockI18nRegistration = () =>
+      Registration.instance(I18N, {
+        tr: (s: string) => String(s),
+      });
+    return [
+      KGuilder,
+      createMockStoreRegistration(),
+      createMockI18nRegistration(),
+      Global,
+      ValueConverter.define(
+        'percentage',
+        class {
+          toView = (v: string) => `${v}%`;
+        },
+      ),
+    ];
+  }
+});

--- a/src/pages/treasury/pages/overview/elements/assets-card/assets-card.spec.ts
+++ b/src/pages/treasury/pages/overview/elements/assets-card/assets-card.spec.ts
@@ -1,3 +1,4 @@
+import '../../../../../../utils-testing/setup-testing';
 import { AssetsCard } from './assets-card';
 import { Global } from '../../../../../../hooks';
 import { I18N } from '@aurelia/i18n';
@@ -5,52 +6,49 @@ import { IStore } from '../../../../../../stores';
 import { Registration } from 'aurelia';
 import { createFixture } from '@aurelia/testing';
 import { describe, expect, it } from 'vitest';
-import { preparePlatform } from '../../../../../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('assets-card', () => {
   it('should have a k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<assets-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelector('#t-o-ac-card')).exist;
   });
+
   it('should have a title k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<assets-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const card = appHost.querySelector('#t-o-ac-card');
     expect(card?.getAttribute('title')).exist;
   });
+
   it('should have a card nav component', async () => {
     const { appHost } = await createFixture
       .html(`<assets-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelector('card-nav')).exist;
   });
+
   it('should have an assets component', async () => {
     const { appHost } = await createFixture
       .html(`<assets-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelector('assets')).exist;
   });
+
   it('should not have a transaction history component', async () => {
     const { appHost } = await createFixture
       .html(`<assets-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelector('transaction-history')).toBeNull();
   });
+
   function getRegistrations() {
     const createMockStoreRegistration = () => Registration.instance(IStore, {});
     const createMockI18nRegistration = () =>

--- a/src/pages/treasury/pages/overview/elements/token-info-card/token-info-card.spec.ts
+++ b/src/pages/treasury/pages/overview/elements/token-info-card/token-info-card.spec.ts
@@ -1,3 +1,4 @@
+import '../../../../../../utils-testing/setup-testing';
 import { CurrencyValueConverter } from '../../../../../../../design-system/value-converters';
 import { Global } from '../../../../../../hooks';
 import { I18N } from '@aurelia/i18n';
@@ -7,23 +8,19 @@ import { Registration } from 'aurelia';
 import { TokenInfoCard } from './token-info-card';
 import { createFixture } from '@aurelia/testing';
 import { describe, expect, it } from 'vitest';
-import { preparePlatform } from '../../../../../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('token-info-card', () => {
   it('should have a k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<token-info-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelector('#t-o-tic-card')).exist;
   });
+
   it('should have a color, title and avatar on the k-card', async () => {
     const { appHost } = await createFixture
       .html(`<token-info-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const kCard = appHost.querySelector('#t-o-tic-card');
@@ -31,10 +28,10 @@ describe('token-info-card', () => {
     expect(kCard?.hasAttribute('title')).true;
     expect(kCard?.hasAttribute('title-avatar')).true;
   });
+
   it('should have a 3 col k-grid with three labels and tooltips', async () => {
     const { appHost } = await createFixture
       .html(`<token-info-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const kGrid = appHost.querySelector('#t-o-tic-stats');
@@ -43,10 +40,10 @@ describe('token-info-card', () => {
     expect(labels).toHaveLength(3);
     labels?.forEach((label) => expect(label.getAttribute('tooltip-text')).exist);
   });
+
   it('should have supply distribution with tooltip and 3 treasury percentages', async () => {
     const { appHost } = await createFixture
       .html(`<token-info-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const supplyDistribution = appHost.querySelector('#t-o-tic-supply');
@@ -54,6 +51,7 @@ describe('token-info-card', () => {
     const stats = supplyDistribution?.querySelectorAll('k-text');
     expect(stats).toHaveLength(3);
   });
+
   function getRegistrations() {
     const createMockStoreRegistration = () => Registration.instance(IStore, {});
     const createMockI18nRegistration = () =>

--- a/src/pages/treasury/pages/overview/elements/value-by-asset-type-card/value-by-asset-type-card.spec.ts
+++ b/src/pages/treasury/pages/overview/elements/value-by-asset-type-card/value-by-asset-type-card.spec.ts
@@ -1,3 +1,4 @@
+import '../../../../../../utils-testing/setup-testing';
 import { Global } from '../../../../../../hooks';
 import { I18N } from '@aurelia/i18n';
 import { IDesignSystemConfiguration } from '../../../../../../../design-system/configuration';
@@ -6,48 +7,46 @@ import { Registration } from 'aurelia';
 import { ValueByAssetTypeCard } from './value-by-asset-type-card';
 import { createFixture } from '@aurelia/testing';
 import { describe, expect, it } from 'vitest';
-import { preparePlatform } from '../../../../../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('value-by-asset-type-card', () => {
   it('should have a k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<value-by-asset-type-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelector('#t-o-vbatc-card')).exist;
   });
+
   it('should have a title k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<value-by-asset-type-card>`)
-      .component({})
+
       .deps(...getRegistrations())
       .build().started;
     const card = appHost.querySelector('#t-o-vbatc-card');
     expect(card?.getAttribute('title')).exist;
   });
+
   it('should have a k-chart doughnut component', async () => {
     const { appHost } = await createFixture
       .html(`<value-by-asset-type-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const chart = appHost.querySelector('#t-o-vbatc-chart');
     expect(chart).exist;
     expect(chart?.getAttribute('type')).eq('doughnut');
   });
+
   it('should have a chart legend with 3 values', async () => {
     const { appHost } = await createFixture
       .html(`<value-by-asset-type-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const chart = appHost.querySelector('#t-o-vbatc-legend');
     expect(chart).exist;
     expect(chart?.querySelectorAll('avatar-text')).toHaveLength(3);
   });
+
   function getRegistrations() {
     const createMockStoreRegistration = () => Registration.instance(IStore, {});
     const createMockI18nRegistration = () =>

--- a/src/pages/treasury/pages/overview/elements/value-card/value-card.spec.ts
+++ b/src/pages/treasury/pages/overview/elements/value-card/value-card.spec.ts
@@ -1,3 +1,4 @@
+import '../../../../../../utils-testing/setup-testing';
 import { CurrencyValueConverter } from '../../../../../../../design-system/value-converters';
 import { Global } from '../../../../../../hooks';
 import { I18N } from '@aurelia/i18n';
@@ -7,29 +8,26 @@ import { Registration } from 'aurelia';
 import { ValueCard } from './value-card';
 import { createFixture } from '@aurelia/testing';
 import { describe, expect, it } from 'vitest';
-import { preparePlatform } from '../../../../../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('value-card', () => {
   it('should have a k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<value-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelector('#t-o-vc-card')).exist;
   });
+
   it('should have a title and tooltip on the k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<value-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const card = appHost.querySelector('#t-o-vc-card');
     expect(card?.getAttribute('title')).exist;
     expect(card?.getAttribute('tooltip-text')).exist;
   });
+
   function getRegistrations() {
     const createMockStoreRegistration = () => Registration.instance(IStore, {});
     const createMockI18nRegistration = () =>

--- a/src/pages/treasury/pages/overview/elements/value-over-time-card/value-over-time-card.spec.ts
+++ b/src/pages/treasury/pages/overview/elements/value-over-time-card/value-over-time-card.spec.ts
@@ -1,3 +1,4 @@
+import '../../../../../../utils-testing/setup-testing';
 import { Global } from '../../../../../../hooks';
 import { I18N } from '@aurelia/i18n';
 import { IDesignSystemConfiguration } from '../../../../../../../design-system/configuration';
@@ -6,47 +7,44 @@ import { Registration } from 'aurelia';
 import { ValueOverTimeCard } from './value-over-time-card';
 import { createFixture } from '@aurelia/testing';
 import { describe, expect, it } from 'vitest';
-import { preparePlatform } from '../../../../../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('value-over-time-card', () => {
   it('should have a k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<value-over-time-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelector('#t-o-votc-card')).exist;
   });
+
   it('should have a title k-card component', async () => {
     const { appHost } = await createFixture
       .html(`<value-over-time-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const card = appHost.querySelector('#t-o-votc-card');
     expect(card?.getAttribute('title')).exist;
   });
+
   it('should have a chart time filter component with text on the right', async () => {
     const { appHost } = await createFixture
       .html(`<value-over-time-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const filter = appHost.querySelector('chart-time-filter');
     expect(filter).exist;
     expect(filter?.innerHTML).contains('k-text');
   });
+
   it('should have a line chart', async () => {
     const { appHost } = await createFixture
       .html(`<value-over-time-card>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const chart = appHost.querySelector('k-chart');
     expect(chart).exist;
   });
+
   function getRegistrations() {
     const createMockStoreRegistration = () => Registration.instance(IStore, {});
     const createMockI18nRegistration = () =>

--- a/src/pages/treasury/pages/overview/overview.spec.ts
+++ b/src/pages/treasury/pages/overview/overview.spec.ts
@@ -1,3 +1,4 @@
+import '../../../../utils-testing/setup-testing';
 import { CurrencyValueConverter } from '../../../../../design-system/value-converters';
 import { Global } from '../../../../hooks';
 import { I18N } from '@aurelia/i18n';
@@ -7,69 +8,66 @@ import { Overview } from './overview';
 import { Registration } from 'aurelia';
 import { createFixture } from '@aurelia/testing';
 import { describe, expect, it } from 'vitest';
-import { preparePlatform } from '../../../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('overview', () => {
   it('should have a k-page component', async () => {
     const { appHost } = await createFixture
       .html(`<overview>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelectorAll('k-page')).toHaveLength(1);
   });
+
   it('should have a tile and description in the k-page component', async () => {
     const { appHost } = await createFixture
       .html(`<overview>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     const kPage = appHost.querySelectorAll('k-page');
     expect(kPage[0].hasAttribute('title')).true;
     expect(kPage[0].hasAttribute('description')).true;
   });
+
   it('should have a token info card component', async () => {
     const { appHost } = await createFixture
       .html(`<overview>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelectorAll('token-info-card')).toHaveLength(1);
   });
+
   it('should have a value card component', async () => {
     const { appHost } = await createFixture
       .html(`<overview>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelectorAll('value-card')).toHaveLength(1);
   });
+
   it('should have a value by asset type card component', async () => {
     const { appHost } = await createFixture
       .html(`<overview>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelectorAll('value-by-asset-type-card')).toHaveLength(1);
   });
+
   it('should have a value over time card component', async () => {
     const { appHost } = await createFixture
       .html(`<overview>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelectorAll('value-over-time-card')).toHaveLength(1);
   });
+
   it('should have an assets card component', async () => {
     const { appHost } = await createFixture
       .html(`<overview>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.querySelectorAll('assets-card')).toHaveLength(1);
   });
+
   function getRegistrations() {
     const createMockStoreRegistration = () => Registration.instance(IStore, {});
     const createMockI18nRegistration = () =>

--- a/src/pages/treasury/treasury.spec.ts
+++ b/src/pages/treasury/treasury.spec.ts
@@ -1,3 +1,4 @@
+import '../../utils-testing/setup-testing';
 import { Global } from '../../hooks';
 import { I18N } from '@aurelia/i18n';
 import { IStore } from '../../stores';
@@ -5,24 +6,20 @@ import { Registration } from 'aurelia';
 import { Treasury } from './treasury';
 import { createFixture } from '@aurelia/testing';
 import { describe, expect, it } from 'vitest';
-import { preparePlatform } from '../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('treasury', () => {
   it('should have an au-viewport with overview as default', async () => {
     const { appHost } = await createFixture
       .html(`<treasury>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
 
     expect(appHost.innerHTML).toContain('<au-viewport default="overview">');
   });
+
   it('should have an inner-nav', async () => {
     const { appHost } = await createFixture
       .html(`<treasury>`)
-      .component({})
       .deps(...getRegistrations())
       .build().started;
     expect(appHost.innerHTML).toContain('<inner-nav');

--- a/src/resources/elements/account-menu/account-menu.spec.ts
+++ b/src/resources/elements/account-menu/account-menu.spec.ts
@@ -1,3 +1,4 @@
+import '../../../utils-testing/setup-testing';
 import { AccountMenu } from './account-menu';
 import { Global } from '../../../hooks';
 import { I18N } from '@aurelia/i18n';
@@ -6,9 +7,6 @@ import { Registration } from 'aurelia';
 import { SmallHexStringValueConverter } from '../../value-converters';
 import { createFixture } from '@aurelia/testing';
 import { describe, expect, it } from 'vitest';
-import { preparePlatform } from '../../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('<account-menu />', () => {
   it('displays store connected wallet address', async () => {

--- a/src/resources/elements/activity-menu/activity-menu.spec.ts
+++ b/src/resources/elements/activity-menu/activity-menu.spec.ts
@@ -1,3 +1,4 @@
+import '../../../utils-testing/setup-testing';
 import { ActivityMenu } from './activity-menu';
 import { Global } from '../../../hooks/';
 import { I18N } from '@aurelia/i18n';
@@ -6,9 +7,6 @@ import { Registration } from 'aurelia';
 import { TakeValueConverter } from '../../../../design-system/value-converters';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createFixture } from '@aurelia/testing';
-import { preparePlatform } from '../../../utils-testing/setup-testing';
-
-preparePlatform();
 
 describe('<activity-menu />', () => {
   let transactions: Transaction[] = [];

--- a/src/utils-testing/setup-testing.ts
+++ b/src/utils-testing/setup-testing.ts
@@ -8,3 +8,5 @@ export const preparePlatform = () => {
   setPlatform(platform);
   return platform;
 };
+
+preparePlatform();


### PR DESCRIPTION
Per title, I'm trying to reduce the noises to the most minimal so we can write/read/maintain tests with the least effort.

Also partially address #106 by setting up a basic test and a few todos for it.